### PR TITLE
update docs adding n which shows the number of blocks to be generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 1. connect elements container  
 `docker exec -it elements /bin/bash`
 
-2. generate block  
-`ecli generate`
+2. generate block where n is the number of blocks to generate
+`ecli generate n`
 
 3. call API  
 `curl http://localhost:3002/blocks/tip/hash`


### PR DESCRIPTION
Minor change to reflect the additional argument n which is required by `ecli generate`